### PR TITLE
update to apple pay

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,19 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: '/.well-known/apple-developer-merchantid-domain-association',
+        headers: [
+          {
+            key: 'Content-Type',
+            value: 'application/text',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
This pull request updates the Next.js configuration to add a custom HTTP header for the Apple Pay domain association file. This change ensures that requests to the `/.well-known/apple-developer-merchantid-domain-association` path return the correct `Content-Type` header, which is required for Apple Pay integration.

Apple Pay integration:

* Added an `async headers()` function to `next.config.ts` to serve the `/.well-known/apple-developer-merchantid-domain-association` file with a `Content-Type: application/text` header.