### PR TITLE
Fix Footer image oversizing

### DIFF
--- a/components/global/Footer.tsx
+++ b/components/global/Footer.tsx
@@ -29,7 +29,14 @@ export default function Footer() {
               transition={{ duration: 0.2 }}
             >
               <Link href="/" className="">
-                <Image src={Logo} alt="Logo" />
+                <Image
+                  src={Logo}
+                  alt="Logo"
+                  width={90}
+                  height={45}
+                  className="object-contain"
+                  style={{ width: '90px', height: '45px' }}
+                />
               </Link>
             </motion.div>
             <motion.p


### PR DESCRIPTION
This pull request makes a small update to the `Footer` component by specifying the width, height, and object-fit style for the logo image to ensure consistent display.

* Set explicit `width`, `height`, and `object-contain` styling for the logo image in the `Footer` component (`Footer.tsx`).